### PR TITLE
Unit-Tests: Added plugin to run tests from maven and another one to g…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,14 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Added by Luis -->
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.10.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency> 
 		</dependencies>
 	</dependencyManagement>
 
@@ -300,6 +308,12 @@
 			<version>${camel-version}</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- Added by Luis -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency> 
 
 	</dependencies>
 
@@ -375,8 +389,31 @@
 				</executions>
 			</plugin>
 			<!-- end::unpack[] -->
-
-
+			<!-- Added by Luis --> 
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<!-- attached to Maven test phase -->
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti67/IdRequestConverterTest.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti67/IdRequestConverterTest.java
@@ -1,0 +1,46 @@
+package ch.bfh.ti.i4mi.mag.mhd.iti67;
+import ch.bfh.ti.i4mi.mag.TestBase;
+import org.junit.jupiter.api.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.GetDocumentsQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryRegistryTransformer;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.requests.AdhocQueryRequestValidator;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.ITI_18;
+
+public class IdRequestConverterTest extends TestBase{
+    private final IdRequestConverter _sut;
+    private final QueryRegistryTransformer _queryRegistryTransformer;
+
+    public IdRequestConverterTest() {
+        _sut = new IdRequestConverter();
+        _queryRegistryTransformer = new QueryRegistryTransformer();
+    }
+
+    @Test
+    public void idToGetDocumentQuery_MissingFhirHeader_null() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("");
+        assertNull(result);
+    }
+
+    @Test
+    public void idToGetDocumentQuery_NotContainingSlash_null() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("some-fhir-uri");
+        assertNull(result);
+    }
+
+    @Test
+    public void idToGetDocumentQuery_ValidFhirHttpUri_QueryValidated() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("some-fhir-uri/12345");
+
+        var uuid = ((GetDocumentsQuery) result.getQuery()).getUuids().get(0);
+        assertTrue(result.getQuery() instanceof GetDocumentsQuery);
+        assertEquals("urn:uuid:12345", uuid);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(result);
+        new AdhocQueryRequestValidator().validate(ebXmlResult, ITI_18);
+    }
+    
+}
+


### PR DESCRIPTION
I added two plugins to the mag, according to our discussions.
It would allow us to run the unit tests using maven, from the command line.
I also added as requested the plugin to generate a code coverage report.